### PR TITLE
:+1: iOS の場合に TopAppBar を非表示に変更

### DIFF
--- a/app/ios/Modules/Sources/Navigation/RootView.swift
+++ b/app/ios/Modules/Sources/Navigation/RootView.swift
@@ -22,6 +22,7 @@ public struct RootView: View {
                                 stateMachine.dispatch(intent: .routing(.top))
                             }
                         )
+                        .navigationTitle("ログイン")
                         .navigationBarBackButtonHidden(true)
                         .ignoresSafeArea(.keyboard)
                     case .top:
@@ -43,10 +44,13 @@ public struct RootView: View {
                                 stateMachine.dispatch(intent: .routing(.scheduleDetail(scheduleId: scheduleId)))
                             }
                         )
+                        .navigationTitle("スケジュール一覧")
                     case .scheduleDetail(let scheduleId):
                         ComposeScheduleDetailScreen(scheduleId: scheduleId)
+                            .navigationTitle("スケジュール詳細")
                     case .settings:
                         ComposeSettingsScreen()
+                            .navigationTitle("設定")
                     }
                 }
         }

--- a/feature/auth/src/commonMain/kotlin/club/nito/feature/auth/LoginScreen.kt
+++ b/feature/auth/src/commonMain/kotlin/club/nito/feature/auth/LoginScreen.kt
@@ -31,6 +31,7 @@ public fun LoginRoute(
     viewModel: LoginScreenStateMachine = koinStateMachine(LoginScreenStateMachine::class),
     onLoggedIn: () -> Unit = {},
     onRegisterClick: () -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     viewModel.event.collectAsState(initial = null).value?.let {
         LaunchedEffect(it.hashCode()) {
@@ -63,16 +64,19 @@ private fun LoginScreen(
     uiState: LoginScreenUiState,
     snackbarHostState: SnackbarHostState,
     dispatch: (LoginScreenIntent) -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        text = "サインイン",
-                    )
-                },
-            )
+            if (hideTopAppBar.not()) {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = "サインイン",
+                        )
+                    },
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->

--- a/feature/auth/src/iosMain/kotlin/club/nito/feature/auth/LoginScreen.ios.kt
+++ b/feature/auth/src/iosMain/kotlin/club/nito/feature/auth/LoginScreen.ios.kt
@@ -15,6 +15,7 @@ public fun LoginRouteViewController(
             viewModel = viewModel,
             onLoggedIn = onLoggedIn,
             onRegisterClick = onRegisterClick,
+            hideTopAppBar = true,
         )
     }
 }

--- a/feature/schedule/src/commonMain/kotlin/club/nito/feature/schedule/detail/ScheduleDetailScreen.kt
+++ b/feature/schedule/src/commonMain/kotlin/club/nito/feature/schedule/detail/ScheduleDetailScreen.kt
@@ -74,6 +74,7 @@ public fun ScheduleDetailRoute(
     stateMachine: ScheduleDetailStateMachine = koinStateMachine(ScheduleDetailStateMachine::class) {
         parametersOf(id)
     },
+    hideTopAppBar: Boolean = false,
 ) {
     stateMachine.event.collectAsState(initial = null).value?.let {
         LaunchedEffect(it.hashCode()) {
@@ -96,6 +97,7 @@ public fun ScheduleDetailRoute(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         dispatch = stateMachine::dispatch,
+        hideTopAppBar = hideTopAppBar,
     )
 }
 
@@ -105,6 +107,7 @@ private fun ScheduleDetailScreen(
     uiState: ScheduleDetailScreenUiState,
     snackbarHostState: SnackbarHostState,
     dispatch: (ScheduleDetailIntent) -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val localDensity = LocalDensity.current
@@ -116,13 +119,15 @@ private fun ScheduleDetailScreen(
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        text = "スケジュール詳細",
-                    )
-                },
-            )
+            if (hideTopAppBar.not()) {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = "スケジュール詳細",
+                        )
+                    },
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { innerPadding ->

--- a/feature/schedule/src/commonMain/kotlin/club/nito/feature/schedule/list/ScheduleListScreen.kt
+++ b/feature/schedule/src/commonMain/kotlin/club/nito/feature/schedule/list/ScheduleListScreen.kt
@@ -25,6 +25,7 @@ import club.nito.feature.schedule.component.ScheduleListSection
 public fun ScheduleListRoute(
     stateMachine: ScheduleListStateMachine = koinStateMachine(ScheduleListStateMachine::class),
     onScheduleItemClick: (ScheduleId) -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     stateMachine.event.collectAsState(initial = null).value?.let {
         LaunchedEffect(it.hashCode()) {
@@ -47,6 +48,7 @@ public fun ScheduleListRoute(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         dispatch = stateMachine::dispatch,
+        hideTopAppBar = hideTopAppBar,
     )
 }
 
@@ -56,18 +58,21 @@ private fun ScheduleListScreen(
     uiState: ScheduleListScreenUiState,
     snackbarHostState: SnackbarHostState,
     dispatch: (ScheduleListIntent) -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     val confirmParticipateDialog = uiState.confirmParticipateDialog
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        text = "スケジュール一覧",
-                    )
-                },
-            )
+            if (hideTopAppBar.not()) {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = "スケジュール一覧",
+                        )
+                    },
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { innerPadding ->

--- a/feature/schedule/src/iosMain/kotlin/club/nito/feature/schedule/detail/ScheduleDetailScreen.ios.kt
+++ b/feature/schedule/src/iosMain/kotlin/club/nito/feature/schedule/detail/ScheduleDetailScreen.ios.kt
@@ -14,6 +14,7 @@ public fun ScheduleDetailRouteViewController(
         ScheduleDetailRoute(
             id = id,
             stateMachine = stateMachine,
+            hideTopAppBar = true,
         )
     }
 }

--- a/feature/schedule/src/iosMain/kotlin/club/nito/feature/schedule/list/ScheduleListScreen.ios.kt
+++ b/feature/schedule/src/iosMain/kotlin/club/nito/feature/schedule/list/ScheduleListScreen.ios.kt
@@ -14,6 +14,7 @@ public fun ScheduleListRouteViewController(
         ScheduleListRoute(
             stateMachine = stateMachine,
             onScheduleItemClick = onScheduleItemClick,
+            hideTopAppBar = true,
         )
     }
 }

--- a/feature/settings/src/commonMain/kotlin/club/nito/feature/settings/SettingsScreen.kt
+++ b/feature/settings/src/commonMain/kotlin/club/nito/feature/settings/SettingsScreen.kt
@@ -33,6 +33,7 @@ import club.nito.feature.settings.component.ModifyPasswordDialog
 public fun SettingsRoute(
     stateMachine: SettingsScreenStateMachine = koinStateMachine(SettingsScreenStateMachine::class),
     onSignedOut: () -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     stateMachine.event.collectAsState(initial = null).value?.let {
         LaunchedEffect(it.hashCode()) {
@@ -55,6 +56,7 @@ public fun SettingsRoute(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         dispatch = stateMachine::dispatch,
+        hideTopAppBar = hideTopAppBar,
     )
 }
 
@@ -64,18 +66,21 @@ private fun SettingsScreen(
     uiState: SettingsScreenUiState,
     snackbarHostState: SnackbarHostState,
     dispatch: (SettingsScreenIntent) -> Unit = {},
+    hideTopAppBar: Boolean = false,
 ) {
     val modifyPassword = uiState.modifyPassword
 
     Scaffold(
         topBar = {
-            CenterAlignedTopAppBar(
-                title = {
-                    Text(
-                        text = "設定",
-                    )
-                },
-            )
+            if (hideTopAppBar.not()) {
+                CenterAlignedTopAppBar(
+                    title = {
+                        Text(
+                            text = "設定",
+                        )
+                    },
+                )
+            }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { padding ->

--- a/feature/settings/src/iosMain/kotlin/club/nito/feature/settings/SettingsScreen.ios.kt
+++ b/feature/settings/src/iosMain/kotlin/club/nito/feature/settings/SettingsScreen.ios.kt
@@ -13,6 +13,7 @@ public fun SettingsScreenUIViewController(
         SettingsRoute(
             stateMachine = stateMachine,
             onSignedOut = onLoggedOut,
+            hideTopAppBar = true,
         )
     }
 }


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

iOS の場合に TopAppBar を非表示に変更します。

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->

特になし

## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [x] 今日中に見てもらいたい 🚗
- [ ] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- 

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ログイン画面、スケジュール一覧、スケジュール詳細、設定画面にナビゲーションタイトルを追加しました。
  - ログインルート、スケジュール詳細ルート、スケジュールリストルート、設定ルートに新しいパラメータ `hideTopAppBar` を追加し、トップアプリバーの表示を制御できるようにしました。

- **バグ修正**
  - トップアプリバーの表示に関する複数の画面での挙動を修正しました。

- **その他の変更**
  - iOS用の各機能において、トップアプリバーを非表示にするためのパラメータを関数呼び出しに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->