### PR TITLE
ci: bump macos 13 -> 14

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -87,7 +87,7 @@ jobs:
         run: ./gradlew :app:android:assembleDevDebug
 
   check-ios:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: changed
     if: needs.changed.outputs.ios == 'true'
     strategy:


### PR DESCRIPTION
## Issue

- close #ISSUE_NUMBER 🦕

## 概要

<!-- 概要をここに記入してください。 -->

ci の macos を 13 -> 14 にします.

## レビュー観点

<!-- レビュアに確認してほしい事柄を記載してください -->
<!-- 特に、本 PR にてレビュー対象外の内容があれば合わせて記載してください -->

<!--
    (例)
    - warnings が出力されないこと
    - デザインだけ組み込んだので、仕様についてはレビュー対象外として欲しい
    - このコミット xxxxxxx ( commit hash ) を主にレビューして欲しい
-->



## レビューレベル

- [ ] Lv0: まったく見ないで Approve する
- [x] Lv1: ぱっとみて違和感がないかチェックして Approve する
- [ ] Lv2: 仕様レベルまで理解して、仕様通りに動くかある程度検証して Approve する
- [ ] Lv3: 実際に環境で動作確認したうえで Approve する

## レビュー優先度

- [ ] すぐに見てもらいたい ( hotfix など ) 🚀
- [ ] 今日中に見てもらいたい 🚗
- [x] 今日〜明日中で見てもらいたい 🚶
- [ ] 数日以内で見てもらいたい 🐢

## 参考リンク

<!-- 参考文献などがあればここに記入してください。 -->

- https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

## スクリーンショット

|           Before           |           After            |
|:--------------------------:|:--------------------------:|
| <img src="" width="300" /> | <img src="" width="300" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- iOSチェックジョブの環境をmacOS 13から14に更新しました。これにより、互換性とパフォーマンスが向上する可能性があります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->