### PR TITLE
Revert "fix(deps): update dependency io.github.qdsfdhvh:image-loader to v1.8.2"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ logback = "1.5.6"
 graphqlKotlin = "7.1.4"
 kotest = "5.9.1"
 precompose = "1.6.1"
-imageLoader = "1.8.2"
+imageLoader = "1.8.1"
 
 [libraries]
 androidGradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }


### PR DESCRIPTION
Reverts nitoclub/nito-app#430

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Downgraded the `imageLoader` library version from 1.8.2 to 1.8.1, potentially improving compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->